### PR TITLE
Added support for the /delta/latest_cursor endpoint

### DIFF
--- a/src/http/pulled_changes.coffee
+++ b/src/http/pulled_changes.coffee
@@ -58,7 +58,7 @@ class Dropbox.Http.PulledChanges
     @cursorTag = deltaInfo.cursor
     @shouldPullAgain = deltaInfo.has_more
     @shouldBackOff = not @shouldPullAgain
-    if deltaInfo.cursor and deltaInfo.cursor.length
+    if deltaInfo.cursor and deltaInfo.cursor.length and deltaInfo.entries
       @changes = for entry in deltaInfo.entries
         Dropbox.Http.PulledChange.parse entry
     else


### PR DESCRIPTION
I added a method in client.coffee for this endpoint described in the docs here: [/delta/latest_cursor docs](https://www.dropbox.com/developers/core/docs#delta-latest-cursor).

You should **NOT** merge this yet because I actually found a 500 API error which is causing the tests (only when run with the app with only folder access) to fail that I've reported to someone on the API team and will hopefully be fixed soon.

I can comment back when I've verified that the tests pass but I figured I could go ahead and submit it for review.

Thanks!